### PR TITLE
Make it compile under Cygwin

### DIFF
--- a/generic/gitignore.c
+++ b/generic/gitignore.c
@@ -18,6 +18,11 @@
 #include <libgen.h>
 #include <sys/stat.h>
 
+#ifdef __CYGWIN__
+//#include <sys/termios.h>
+#define FNM_EXTMATCH  (1 << 5)
+#endif
+
 bool isfile(const char *path) {
     struct stat statbuf;
     if (lstat(path, &statbuf) != 0) {


### PR DESCRIPTION
glibc in Cygwin seems missing the definition of `FNM_EXTMATCH`. This pull can make it to be compiled successfully. 

BTW, I'm very glad to find your `ff`, a pure C implementation of `fd`. Cygwin is lacking `rust` and `go` but many popular tools are being written in them nowadays. Your `ff` really scratches the itch. Thank you.